### PR TITLE
Add smartcosmos.events.noop config option

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,8 @@ No new features are added in this release.
 
 === Bugfixes & Improvements
 
+* OBJECTS-1237 Event service "noop" profile collides with "docker" profile from smartcosmos/service base Docker image
+
 == Release 3.1.0 (November 18, 2016)
 
 === New Features

--- a/src/main/java/net/smartcosmos/events/resource/EventResource.java
+++ b/src/main/java/net/smartcosmos/events/resource/EventResource.java
@@ -7,7 +7,7 @@ import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Profile;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.support.KafkaHeaders;
@@ -31,7 +31,7 @@ import net.smartcosmos.security.user.SmartCosmosUser;
  */
 @RestController
 @Slf4j
-@Profile("!noop")
+@ConditionalOnProperty(name = "smartcosmos.events.noop", havingValue = "false", matchIfMissing = false)
 public class EventResource {
 
     @Autowired

--- a/src/main/java/net/smartcosmos/events/resource/EventResource.java
+++ b/src/main/java/net/smartcosmos/events/resource/EventResource.java
@@ -31,7 +31,7 @@ import net.smartcosmos.security.user.SmartCosmosUser;
  */
 @RestController
 @Slf4j
-@ConditionalOnProperty(name = "smartcosmos.events.noop", havingValue = "false", matchIfMissing = false)
+@ConditionalOnProperty(name = "smartcosmos.events.noop", havingValue = "false", matchIfMissing = true)
 public class EventResource {
 
     @Autowired

--- a/src/main/java/net/smartcosmos/events/resource/NoOpEventResource.java
+++ b/src/main/java/net/smartcosmos/events/resource/NoOpEventResource.java
@@ -6,7 +6,7 @@ import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Profile;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,7 +26,7 @@ import net.smartcosmos.security.user.SmartCosmosUser;
  */
 @RestController
 @Slf4j
-@Profile("noop")
+@ConditionalOnProperty(name = "smartcosmos.events.noop", havingValue = "true", matchIfMissing = false)
 public class NoOpEventResource {
 
     @Autowired


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes the Noop Event Service to depend on a config flag rather than a Spring profile to avoid conflicts or having to override the `SPRING_PROFILE` environment variable.

Old required configuration:
```
spring:
  profiles:
    active: noop
```

New configuration:
```
smartcosmos:
  events:
    noop: true
```

The default remains the same.

### How is this patch documented?

Code, especially since the `noop` profile also wasn't documented before.

### How was this patch tested?

manually using both Docker and IntelliJ.

#### Depends On

Nothing.