### PR TITLE
Revert "Merge pull request #13 from SMARTRACTECHNOLOGY/bugfix/OBJECTS…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,8 +8,6 @@ No new features are added in this release.
 
 === Bugfixes & Improvements
 
-* OBJECTS-1237 Event service "noop" profile collides with "docker" profile from smartcosmos/service base Docker image
-
 == Release 3.1.0 (November 18, 2016)
 
 === New Features

--- a/src/main/java/net/smartcosmos/events/resource/EventResource.java
+++ b/src/main/java/net/smartcosmos/events/resource/EventResource.java
@@ -7,7 +7,7 @@ import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.support.KafkaHeaders;
@@ -31,7 +31,7 @@ import net.smartcosmos.security.user.SmartCosmosUser;
  */
 @RestController
 @Slf4j
-@ConditionalOnProperty(name = "smartcosmos.events.noop", havingValue = "false", matchIfMissing = true)
+@Profile("!noop")
 public class EventResource {
 
     @Autowired

--- a/src/main/java/net/smartcosmos/events/resource/NoOpEventResource.java
+++ b/src/main/java/net/smartcosmos/events/resource/NoOpEventResource.java
@@ -6,7 +6,7 @@ import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,7 +26,7 @@ import net.smartcosmos.security.user.SmartCosmosUser;
  */
 @RestController
 @Slf4j
-@ConditionalOnProperty(name = "smartcosmos.events.noop", havingValue = "true", matchIfMissing = false)
+@Profile("noop")
 public class NoOpEventResource {
 
     @Autowired


### PR DESCRIPTION
Move back to the profile. We know how to work with this now. Stan is adding an option to set the environment variable in the helm chart, and there is also a pull request to remove the default profile.

https://github.com/SMARTRACTECHNOLOGY/service-docker/pull/2